### PR TITLE
Feat/room leave api

### DIFF
--- a/src/api/roomDetail.api.ts
+++ b/src/api/roomDetail.api.ts
@@ -5,3 +5,8 @@ export const fetchRoomDetail = async (id: string) => {
     const url = `/rooms/${id}`
     return await requestHandler<IroomData>("get", url);
 }
+
+export const exitRoom = async (id : string) => {
+    const url =`/rooms/${id}/leave`
+    return await requestHandler<void>("delete", url)
+}

--- a/src/api/roomDetail.api.ts
+++ b/src/api/roomDetail.api.ts
@@ -10,3 +10,8 @@ export const exitRoom = async (id : string) => {
     const url =`/rooms/${id}/leave`
     return await requestHandler<void>("delete", url)
 }
+
+export const deleteRoom = async (id : string) => {
+    const url =`/rooms/${id}`
+    return await requestHandler<void>("delete", url);
+}

--- a/src/components/buttons/CircleButton.tsx
+++ b/src/components/buttons/CircleButton.tsx
@@ -1,15 +1,19 @@
+import { TButtonColor } from "@/style/theme";
 import React from "react";
 import styled from "styled-components";
 
 type TButtonSize = "large" | "small";
 
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  buttonColor: Extract<TButtonColor, "active" | "delete">;
   children: React.ReactNode;
   buttonSize: TButtonSize;
 }
-const CircleButton = ({ children, buttonSize, ...props }: Props) => {
+const CircleButton = ({ children, buttonSize, buttonColor, ...props }: Props) => {
   return (
-    <CircleButtonStyle $buttonSize={buttonSize} {...props}>
+    <CircleButtonStyle $buttonSize={buttonSize} 
+    $buttonColor={buttonColor}
+    {...props}>
       {children}
     </CircleButtonStyle>
   );
@@ -17,6 +21,7 @@ const CircleButton = ({ children, buttonSize, ...props }: Props) => {
 
 interface CircleButtonStyleProps {
   $buttonSize: TButtonSize;
+  $buttonColor : TButtonColor;
 }
 const CircleButtonStyle = styled.button<CircleButtonStyleProps>`
   display: inline-flex;
@@ -25,9 +30,11 @@ const CircleButtonStyle = styled.button<CircleButtonStyleProps>`
 
   width: ${({ $buttonSize }) => ($buttonSize === "large" ? "70px" : "46px")};
   height: ${({ $buttonSize }) => ($buttonSize === "large" ? "70px" : "46px")};
-  color: ${({ theme }) => theme.color.pink6};
-  background-color:${({ theme}) => theme.color.purewhite};
-  border: 1px solid ${({ theme }) => theme.color.pink6};
+  color: ${({ theme, $buttonColor }) => theme.buttonColor[$buttonColor].color};
+  background-color: ${({ theme, $buttonColor }) =>
+    theme.buttonColor[$buttonColor].background};
+  border: 1px solid
+    ${({ theme, $buttonColor }) => theme.buttonColor[$buttonColor].stroke};
   border-radius: 50%;
   transition: all 0.2s;
   svg {
@@ -37,9 +44,8 @@ const CircleButtonStyle = styled.button<CircleButtonStyleProps>`
 
   cursor: pointer;
   &:hover {
-    color: ${({ theme }) => theme.color.white};
-    background-color: ${({ theme }) => theme.color.pink6};
-    border: none;
+    color: ${({ theme, $buttonColor }) => theme.buttonColor[`${$buttonColor}Hover`]?.color};
+    background-color: ${({ theme, $buttonColor }) => theme.buttonColor[`${$buttonColor}Hover`]?.background};
   }
 `;
 

--- a/src/components/roomDetail/RoomButtons.tsx
+++ b/src/components/roomDetail/RoomButtons.tsx
@@ -1,0 +1,59 @@
+import styled from "styled-components";
+import CircleButton from "../buttons/CircleButton";
+import { RiLogoutBoxRLine } from "react-icons/ri";
+import { MdDeleteForever, MdRemoveRedEye } from "react-icons/md";
+import useExitRoom from "@/hooks/mutations/useExitRoom";
+import { useNavigate } from "react-router-dom";
+import useDeleteRoom from "@/hooks/mutations/useDeleteRoom";
+
+interface Props {
+  id: string | undefined;
+}
+
+const RoomButtons = ({ id }: Props) => {
+  const { mutate: exitRoom } = useExitRoom(id);
+  const { mutate: deleteRoom } = useDeleteRoom(id);
+  const navigate = useNavigate();
+
+  const lookArountButtonHandler = () => {
+    navigate("/");
+  };
+
+  const exitButtonHandler = () => {
+    exitRoom();
+  };
+
+  const deleteButtonHandler = () => {
+    deleteRoom();
+  };
+
+  return (
+    <RoomButtonsStyle>
+      <div className="deleteButton">
+        <CircleButton buttonSize={"large"} onClick={deleteButtonHandler}>
+          <MdDeleteForever />
+        </CircleButton>
+      </div>
+      <div className="exitButton">
+        <CircleButton buttonSize={"large"} onClick={exitButtonHandler}>
+          <RiLogoutBoxRLine />
+        </CircleButton>
+      </div>
+      <div className="lookAroundButton">
+        <CircleButton buttonSize={"large"} onClick={lookArountButtonHandler}>
+          <MdRemoveRedEye />
+        </CircleButton>
+      </div>
+    </RoomButtonsStyle>
+  );
+};
+
+const RoomButtonsStyle = styled.div`
+  display: flex;
+  gap: 20px;
+  position: absolute;
+  bottom: 50px;
+  right: 50px;
+`;
+
+export default RoomButtons;

--- a/src/components/roomDetail/RoomButtons.tsx
+++ b/src/components/roomDetail/RoomButtons.tsx
@@ -30,17 +30,17 @@ const RoomButtons = ({ id }: Props) => {
   return (
     <RoomButtonsStyle>
       <div className="deleteButton">
-        <CircleButton buttonSize={"large"} onClick={deleteButtonHandler}>
+        <CircleButton buttonColor="delete" buttonSize={"large"} onClick={deleteButtonHandler}>
           <MdDeleteForever />
         </CircleButton>
       </div>
       <div className="exitButton">
-        <CircleButton buttonSize={"large"} onClick={exitButtonHandler}>
+        <CircleButton buttonColor="active" buttonSize={"large"} onClick={exitButtonHandler}>
           <RiLogoutBoxRLine />
         </CircleButton>
       </div>
       <div className="lookAroundButton">
-        <CircleButton buttonSize={"large"} onClick={lookArountButtonHandler}>
+        <CircleButton buttonColor="active" buttonSize={"large"} onClick={lookArountButtonHandler}>
           <MdRemoveRedEye />
         </CircleButton>
       </div>

--- a/src/components/user/userProfile/UserImage.tsx
+++ b/src/components/user/userProfile/UserImage.tsx
@@ -57,6 +57,7 @@ const UserImage = ({ url, setUrl, setFile }: Props) => {
       <Profile size="large" url={url || ""} />
       {/* input을 대체할 버튼 */}
       <CircleButton
+      buttonColor="active"
         buttonSize="small"
         onClick={() => inputRef.current?.click()}
       >

--- a/src/hooks/mutations/useDeleteRoom.ts
+++ b/src/hooks/mutations/useDeleteRoom.ts
@@ -1,0 +1,33 @@
+import { deleteRoom } from "@/api/roomDetail.api";
+import { useMutation, UseMutationResult, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import toast from "react-hot-toast";
+import { useNavigate } from "react-router-dom";
+
+const useDeleteRoom = (
+    roomId: string | undefined
+): UseMutationResult<any, Error, void, unknown> => {
+    const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: () => {
+            if (!roomId) {
+                return Promise.reject(new Error('유효하지 않은 방 ID입니다.'));
+            }
+            return deleteRoom(roomId);
+        },
+        onSuccess: () => {
+            toast.success('성공적으로 방을 삭제하셨습니다.');
+            queryClient.invalidateQueries({ queryKey: ['rooms'] });
+            navigate(`/`);
+        },
+        onError: (error: AxiosError | Error) => {
+            const message = error instanceof AxiosError 
+                ? error.response?.data?.message || '에러가 발생하였습니다'
+                : error.message;
+            toast.error(message);
+        }
+    });
+}
+
+export default useDeleteRoom;

--- a/src/hooks/mutations/useExitRoom.ts
+++ b/src/hooks/mutations/useExitRoom.ts
@@ -1,0 +1,33 @@
+import { exitRoom } from "@/api/roomDetail.api";
+import { useMutation, UseMutationResult, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import toast from "react-hot-toast";
+import { useNavigate } from "react-router-dom";
+
+const useExitRoom = (
+    roomId: string | undefined
+): UseMutationResult<any, Error, void, unknown> => {
+    const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: () => {
+            if (!roomId) {
+                return Promise.reject(new Error('유효하지 않은 방 ID입니다.'));
+            }
+            return exitRoom(roomId);
+        },
+        onSuccess: () => {
+            toast.success('그룹을 떠나셨습니다.');
+            queryClient.invalidateQueries({ queryKey: ['rooms'] });
+            navigate(`/`);
+        },
+        onError: (error: AxiosError | Error) => {
+            const message = error instanceof AxiosError 
+                ? error.response?.data?.message || '에러가 발생하였습니다'
+                : error.message;
+            toast.error(message);
+        }
+    });
+}
+
+export default useExitRoom;

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -109,7 +109,7 @@ const Main = () => {
           {pagination && <Pagination pagination={pagination} />}
         </div>
         <div className="createButton" onClick={handleCreateButtonClick}>
-          <CircleButton buttonSize="large">
+          <CircleButton buttonColor="active" buttonSize="large">
             <IoMdAdd />
           </CircleButton>
         </div>

--- a/src/pages/Main/MainStyle.ts
+++ b/src/pages/Main/MainStyle.ts
@@ -59,7 +59,7 @@ export const MainStyle = styled.div`
   }
 
   .createButton {
-    position: fixed;
+    position: absolute;
     bottom: 50px;
     right: 50px;
   }

--- a/src/pages/RoomDetail.tsx
+++ b/src/pages/RoomDetail.tsx
@@ -10,11 +10,15 @@ import SquareButton from "@/components/buttons/SquareButton";
 import useEmitSocket from "@/hooks/useEmitSocket";
 import useFetchRoomDetail from "@/hooks/queries/useFetchRoomDetail";
 import useTimer from "@/hooks/useTimer";
+import { MdRemoveRedEye } from "react-icons/md";
+import { exitRoom } from "@/api/roomDetail.api";
+import useExitRoom from "@/hooks/mutations/useExitRoom";
 
 const RoomDetail = () => {
   const { id } = useParams<{ id: string }>();
   const [activeSound, setActiveSound] = useState<boolean>(false);
   const { data: roomData, isLoading, error } = useFetchRoomDetail(id);
+  const { mutate } = useExitRoom(id);
   const {
     syncedIsRunning,
     syncedAllParticipants,
@@ -26,13 +30,22 @@ const RoomDetail = () => {
 
   console.log(syncedAllParticipants);
 
-  const {timerTime, status} = useTimer({roomData, syncedStartedAt, syncedIsRunning, syncedCurrentCycles})
+  const { timerTime, status } = useTimer({
+    roomData,
+    syncedStartedAt,
+    syncedIsRunning,
+    syncedCurrentCycles
+  });
   const soundHandler = () => {
     setActiveSound(!activeSound);
   };
 
-  const exitButtonHandler = () => {
+  const lookArountButtonHandler = () => {
     navigate("/");
+  };
+
+  const exitButtonHandler = () => {
+    mutate();
   };
 
   if (isLoading) {
@@ -67,10 +80,18 @@ const RoomDetail = () => {
       >
         시작하기
       </SquareButton>
-      <div className="exitButton">
-        <CircleButton buttonSize={"large"} onClick={exitButtonHandler}>
+      <div className="buttons">
+        <div className="exitButton">
+          <CircleButton buttonSize={"large"} onClick={exitButtonHandler}>
           <RiLogoutBoxRLine />
-        </CircleButton>
+          </CircleButton>
+        </div>
+        <div className="lookAroundButton">
+          <CircleButton buttonSize={"large"} onClick={lookArountButtonHandler}>
+            
+            <MdRemoveRedEye />
+          </CircleButton>
+        </div>
       </div>
     </RoomDetailStyle>
   );
@@ -83,20 +104,21 @@ const RoomDetailStyle = styled.div`
   justify-content: center;
   align-items: center;
   position: relative;
+  .buttons {
+    display: flex;
+    gap: 20px;
+    position: absolute;
+    bottom: 50px;
+    right: 50px;
+  }
 
   .muteIcon {
     position: absolute;
-    top:40px;
+    top: 40px;
     right: 50px;
     font-size: 50px;
     color: #ff8080;
     cursor: pointer;
-  }
-
-  .exitButton {
-    position: absolute;
-    bottom: 50px;
-    right: 50px;
   }
 `;
 export default RoomDetail;

--- a/src/pages/RoomDetail.tsx
+++ b/src/pages/RoomDetail.tsx
@@ -1,24 +1,19 @@
-import CircleButton from "@/components/buttons/CircleButton";
 import Drawer from "@/components/drawer/Drawer";
 import Timer from "@/components/timer/Timer";
 import { useState } from "react";
 import { FaVolumeHigh, FaVolumeXmark } from "react-icons/fa6";
-import { RiLogoutBoxRLine } from "react-icons/ri";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import styled from "styled-components";
 import SquareButton from "@/components/buttons/SquareButton";
 import useEmitSocket from "@/hooks/useEmitSocket";
 import useFetchRoomDetail from "@/hooks/queries/useFetchRoomDetail";
 import useTimer from "@/hooks/useTimer";
-import { MdRemoveRedEye } from "react-icons/md";
-import { exitRoom } from "@/api/roomDetail.api";
-import useExitRoom from "@/hooks/mutations/useExitRoom";
+import RoomButtons from "@/components/roomDetail/RoomButtons";
 
 const RoomDetail = () => {
   const { id } = useParams<{ id: string }>();
   const [activeSound, setActiveSound] = useState<boolean>(false);
   const { data: roomData, isLoading, error } = useFetchRoomDetail(id);
-  const { mutate } = useExitRoom(id);
   const {
     syncedIsRunning,
     syncedAllParticipants,
@@ -26,7 +21,6 @@ const RoomDetail = () => {
     syncedStartedAt,
     handleClickCyclesStartButton
   } = useEmitSocket();
-  const navigate = useNavigate();
 
   console.log(syncedAllParticipants);
 
@@ -38,14 +32,6 @@ const RoomDetail = () => {
   });
   const soundHandler = () => {
     setActiveSound(!activeSound);
-  };
-
-  const lookArountButtonHandler = () => {
-    navigate("/");
-  };
-
-  const exitButtonHandler = () => {
-    mutate();
   };
 
   if (isLoading) {
@@ -76,23 +62,10 @@ const RoomDetail = () => {
       <SquareButton
         buttonColor="active"
         buttonSize="medium"
-        onClick={handleClickCyclesStartButton}
-      >
+        onClick={handleClickCyclesStartButton}>
         시작하기
       </SquareButton>
-      <div className="buttons">
-        <div className="exitButton">
-          <CircleButton buttonSize={"large"} onClick={exitButtonHandler}>
-          <RiLogoutBoxRLine />
-          </CircleButton>
-        </div>
-        <div className="lookAroundButton">
-          <CircleButton buttonSize={"large"} onClick={lookArountButtonHandler}>
-            
-            <MdRemoveRedEye />
-          </CircleButton>
-        </div>
-      </div>
+      <RoomButtons id={id}/>
     </RoomDetailStyle>
   );
 };
@@ -104,13 +77,6 @@ const RoomDetailStyle = styled.div`
   justify-content: center;
   align-items: center;
   position: relative;
-  .buttons {
-    display: flex;
-    gap: 20px;
-    position: absolute;
-    bottom: 50px;
-    right: 50px;
-  }
 
   .muteIcon {
     position: absolute;

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -23,7 +23,8 @@ export type TButtonColor =
   | "defaultHover"
   | "active"
   | "activeHover"
-  | "delete";
+  | "delete"
+  | "deleteHover";
 export type TSquareButtonSize = "large" | "medium" | "small";
 export type ToverLay = "default"
 
@@ -141,9 +142,15 @@ export const light: ITheme = {
       stroke: "#FF8080"
     },
     delete: {
+      color: "#CD1818",
+      background: "#fff",
+      stroke: "#CD1818"
+    },
+    deleteHover : {
       color: "#fff",
       background: "#CD1818",
-      stroke: "#CD1818"
+      stroke: "#fff"
+
     }
   },
   squareButtonSize: {


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 방 삭제하기/나가기 버튼 구현 및 API 연결

### PR Point
- 가독성을 위해 roomDetail 페이지 내부 버튼핸들러 및 렌더영역을 roomButtons 컴포넌트로 분리하였습니다.
- 방 삭제하기/나가기 버튼을 구현하였습니다 (하단 스크린샷 참고)
- 아직 myProfile API의 리액트 쿼리 작업이 끝나지 않아 버튼을 부분적으로 렌더하지 않고 우선 전부 렌더되어지도록 했습니다.
- 방 삭제 버튼을 강조하기 위해 공용 컴포넌트 circleButton이 색을 받을 수 있도록 수정하였습니다. squareButton과 동일한 로직으로 필수인자로 buttonColor  ("active | "default") 를 받고 스타일을 부여하도록 하였습니다. 때문에 userImage에서 사용하고 있는 circleButton에도 active 인자를 추가하였습니다.
<img width="461" alt="image" src="https://github.com/Pogakco/FE/assets/50562562/1aad7dd5-10df-4a97-9932-d14aa195dc1e">


### 📸 스크린샷
![방장-방삭제하기](https://github.com/Pogakco/FE/assets/50562562/3b61977d-14d0-4950-a7a0-8213165d5ba4)
- 방 삭제 ( 방장 )

![참여자-방나가기](https://github.com/Pogakco/FE/assets/50562562/b77a9bdb-99c8-4978-8766-47ca5c4d4ce9)
- 방 나가기 ( 참여자 )

![방장-방나가기](https://github.com/Pogakco/FE/assets/50562562/ba070f0d-0dfe-4034-8d6e-4185adf29bc1)
- 에러 처리

closed #63 
