### PR TITLE
Feat: 타이머 소켓 인증 관련 리스너 함수 추가

### DIFF
--- a/src/constants/socket.ts
+++ b/src/constants/socket.ts
@@ -15,6 +15,8 @@ export const SOCKET_TIMER_EVENTS = {
     SYNC_ALL_LINKED_USERS : "sync-all-linked-user-ids",
     DELETE_ROOM: "delete-room",
     ERROR: "timer-error",
+    REQUEST_AUTH: "request-auth",
+    AUTH_ERROR: "auth-error",
 };
 
 export const SOCKET_TIMER_STATUS = {

--- a/src/hooks/useEmitSocket.ts
+++ b/src/hooks/useEmitSocket.ts
@@ -1,8 +1,10 @@
+import { ERROR_MESSAGE } from "@/constants/errorMessage";
 import {
   SOCKET_CONNECTION,
   SOCKET_TIMER_EVENTS,
   SOCKET_URL
 } from "@/constants/socket";
+import useInitialize from "@/hooks/useInitialize";
 import { errorResponse } from "@/models/error.model";
 import { IParticipant } from "@/models/roomDetail.model";
 import { useEffect, useState } from "react";
@@ -12,6 +14,7 @@ import { Socket, io } from "socket.io-client";
 
 const useEmitSocket = () => {
   const navigate = useNavigate();
+  const { userInitializeAuth } = useInitialize();
   const [socket, setSocket] = useState<Socket | null>(null);
   const [syncedIsRunning, setSyncedIsRunning] = useState<boolean | null>(null);
   const [syncedStartedAt, setSyncedStartedAt] = useState<string | null>(null);
@@ -79,6 +82,13 @@ const useEmitSocket = () => {
       toast.error("방이 삭제되었습니다");
       navigate("/");
     };
+    const onRequestedAuthenticate = () => {
+      userInitializeAuth();
+    };
+    const onAuthError = () => {
+      userInitializeAuth();
+      toast.error(ERROR_MESSAGE['401']);
+    };
     socket.on(SOCKET_TIMER_EVENTS.SYNC_IS_RUNNING, onSyncedIsRunning);
     socket.on(SOCKET_TIMER_EVENTS.SYNC_STARTED_AT, onSyncedStartedAt);
     socket.on(SOCKET_TIMER_EVENTS.SYNC_CURRENT_CYCLES, onSyncedCurrentCycles);
@@ -86,6 +96,8 @@ const useEmitSocket = () => {
     socket.on(SOCKET_TIMER_EVENTS.SYNC_ROOM_DELETED, onSyncedRoomDeleted);
     socket.on(SOCKET_TIMER_EVENTS.ERROR, onSyncedTimeError);
     socket.on(SOCKET_TIMER_EVENTS.SYNC_ALL_LINKED_USERS, onSyncedAllLinkedUserIds);
+    socket.on(SOCKET_TIMER_EVENTS.REQUEST_AUTH, onRequestedAuthenticate);
+    socket.on(SOCKET_TIMER_EVENTS.AUTH_ERROR, onAuthError);
 
     return () => {
       socket.disconnect();


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 소켓에 연결될 때 인증을 거치는데, 토큰 재발급과 인증 에러 처리에 필요한 리스너 함수들을 추가 했습니다. 

### PR Point
- 테스트 해보신다면 백엔드 브랜치는 `fix/69-타이머-소켓-인증-로직-수정`로 스위치 해주세요.
- HTTP 통신과는 다르게 소켓 통신에서는 Response의 쿠키 값을 Set 할 수 없어 클라이언트에 인증 API 호출을 요청해 토큰을 재발급 하고 쿠키에 Set, 인증 실패시 토큰 쿠키 삭제 등을 수행하도록 했습니다.
- 코드 컨벤션에 맞지 않거나 잘못된 부분이 있으면 수정 부탁드립니다.



closed #89 
