### PR TITLE
Style : 방 정보 description 클래스 분리 및 방 제목/설명 유효성 검사 추가

### DIFF
--- a/src/components/cards/RoomListCard.tsx
+++ b/src/components/cards/RoomListCard.tsx
@@ -69,11 +69,21 @@ const RoomListCardStyle = styled.div`
 
   .roomTitle {
     margin-top: 10px;
+    width: 80%;
     font-weight: bold;
     font-size: ${({ theme }) => theme.fontSize.medium};
     display: flex;
     justify-content: center;
     align-items: center;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: box;
+    overflow: hidden;
+    vertical-align: top;
+    text-overflow: ellipsis;
+    word-break: break-all;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
   }
 
   .roomStatus {

--- a/src/components/drawer/drawerContents/RoomInfo.tsx
+++ b/src/components/drawer/drawerContents/RoomInfo.tsx
@@ -56,7 +56,7 @@ const RoomInfo = ({ roomData, isRunning, currentCycle }: Props) => {
       <div className="section-title">공유하기</div>
       <span>
         <FaPaperclip />
-        <div className="description" ref={urlRef} onClick={handleURL} style={{ cursor: 'pointer' }}>
+        <div className="clipboard" ref={urlRef} onClick={handleURL} style={{ cursor: 'pointer' }}>
           {window.location.href}
         </div>
       </span>
@@ -92,6 +92,11 @@ const RoomInfoStyle = styled.div`
   }
 
   .description {
+    font-size: ${({ theme }) => theme.fontSize.small};
+    font-weight: 400;
+  }
+
+  .clipboard {
     font-size: ${({ theme }) => theme.fontSize.small};
     font-weight: 400;
     cursor: pointer;

--- a/src/constants/inputField.tsx
+++ b/src/constants/inputField.tsx
@@ -43,8 +43,8 @@ export const AUTH_INPUT_FIELD_ERROR: { [key in AUTH_TYPE]: string } = {
 type IcreateRoomFormKeys = keyof IcreateRoomForm;
 
 export const CREATE_ROOM_INPUT_FIELD_ERROR : { [key in IcreateRoomFormKeys] : string} = {
-  roomTitle: "",
-  roomDescription: "",
+  roomTitle: "방 제목은 20자 이내여야 합니다.",
+  roomDescription: "방 상세 설명은 80자 이내여야 합니다.",
   focusTime : "집중 시간은 25분에서 60분 사이여야 합니다.",
   shortBreakTime : "짧은 휴식 시간은 5분에서 15분 사이여야 합니다.",
   longBreakTime : "긴 휴식 시간은 30분에서 60분 사이여야 합니다.",
@@ -57,6 +57,7 @@ export const ROOM_CREATE_INFO_FIELD: ICreateInputField[] = [
   {
     name: "방 제목",
     field: "roomTitle",
+    placeHolder: "20자 이내",
     message: CREATE_ROOM_INPUT_FIELD_ERROR.roomTitle,
     regex : CREATE_ROOM_REGEX.roomTitle,
     defaultValue : "",
@@ -64,6 +65,7 @@ export const ROOM_CREATE_INFO_FIELD: ICreateInputField[] = [
   {
     name: "상세 설명",
     field: "roomDescription",
+    placeHolder: "80자 이내",
     message: CREATE_ROOM_INPUT_FIELD_ERROR.roomDescription,
     regex : CREATE_ROOM_REGEX.roomDescription,
     defaultValue : "",

--- a/src/constants/regex.ts
+++ b/src/constants/regex.ts
@@ -7,8 +7,8 @@ export const AUTH_REGEX = {
 };
 
 export const CREATE_ROOM_REGEX = {
-  roomTitle : /.*/,
-  roomDescription: /.*/,
+  roomTitle: /^.{0,20}$/,
+  roomDescription: /^.{0,80}$/,
   focusTime: /^(2[5-9]|[3-5][0-9]|60)$/, // 25에서 60 사이의 숫자
   shortBreakTime: /^[5-9]|1[0-5]$/, // 5에서 15 사이의 숫자
   longBreakTime: /^(3[0-9]|[4-5][0-9]|60)$/, // 30에서 60 사이의 숫자


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 방 정보 description 클래스 분리 및 방 제목/설명 유효성 검사 추가

### PR Point
- 방 정보와 클립보드 클래스를 분리하였습니다. (cursor : poitnter)
- 방 상세 설명과 방 제목의 유효성 검사를 추가하였습니다. ( 방 제목 20자 이내, 방 상세설명 80자 이내 )
- 리스트 카드에서 방 제목 길이 출력 초과 부분을 처리하였습니다 ( 스크린샷 참조 )

### 📸 스크린샷
<img width="294" alt="image" src="https://github.com/user-attachments/assets/2316a3b3-6e63-4ba4-bbb3-a3650d360238">
<img width="232" alt="image" src="https://github.com/user-attachments/assets/f9b9335b-4110-443b-8028-c58ac51e8cd7">


closed #92
