### PR TITLE
Fix: 방 디테일 페이지에서 참여한 유저 정보 초기값 설정 안되어 있는 버그 수정

### DIFF
--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -23,6 +23,7 @@ interface IdrawerData {
     userData : IRoomUserData,  
     participants : IParticipant[]
     activeUsers : number,
+    currentParticipants : number | null
   }>;
   icon: React.FC;
 }
@@ -81,7 +82,7 @@ const Drawer = ({ roomData, isRunning, currentCycle, participants, activeUsers }
       <Overlay open={open} onClick={(e) => handleOverlayClick(e, drawerRef, setOpen, handleSelectDrawer)} />
       <DrawerStyle open={open} ref={drawerRef}>
         <DrawerContents>
-          {selectDrawer === "info" && <RoomInfo roomData={roomData} isRunning={isRunning} currentCycle={currentCycle} />}
+          {selectDrawer === "info" && <RoomInfo roomData={roomData} isRunning={isRunning} currentCycle={currentCycle} currentParticipants={participants? participants.length : 0} />}
           {selectDrawer === "user" && <RoomActiveUser participants={participants} activeUsers={activeUsers}/>}
           {selectDrawer === "community" && <RoomCommunity />}
         </DrawerContents>

--- a/src/components/drawer/drawerContents/RoomInfo.tsx
+++ b/src/components/drawer/drawerContents/RoomInfo.tsx
@@ -11,9 +11,10 @@ interface Props {
   roomData: IroomData;
   isRunning: boolean | null;
   currentCycle: number | null;
+  currentParticipants : number | null;
 }
 
-const RoomInfo = ({ roomData, isRunning, currentCycle }: Props) => {
+const RoomInfo = ({ roomData, isRunning, currentCycle, currentParticipants }: Props) => {
   const urlRef = useRef<HTMLDivElement>(null);
 
   const handleURL = () => {
@@ -38,7 +39,7 @@ const RoomInfo = ({ roomData, isRunning, currentCycle }: Props) => {
       </div>
       <div className="users">
         <FaUser />
-        {roomData.currentParticipants}/{roomData.maxParticipants}
+        {currentParticipants}/{roomData.maxParticipants}
       </div>
       <hr />
       <div className="section-title">방 정보</div>

--- a/src/components/drawer/drawerContents/UserListBox.tsx
+++ b/src/components/drawer/drawerContents/UserListBox.tsx
@@ -13,7 +13,6 @@ interface Props {
 }
 
 const UserListBox = ({ rank, user }: Props) => {
-  console.log(user)
   return (
     <UserListCardStyle $rank={rank} $isCurrentParticipant={user.isCurrentParticipant}>
       {rank <= 2 ? (

--- a/src/pages/RoomDetail.tsx
+++ b/src/pages/RoomDetail.tsx
@@ -104,10 +104,8 @@ const RoomDetail = () => {
             : syncedCurrentCycles
         }
         participants={getUserRankList(
-          status === SOCKET_TIMER_STATUS.SET || !syncedAllParticipants 
-            ? userData.users
-            : syncedAllParticipants,
-          syncedAllLinkeduserIds  
+          syncedAllParticipants,
+          syncedAllLinkeduserIds
         )}
         activeUsers={
           status === SOCKET_TIMER_STATUS.SET || !syncedAllParticipants

--- a/src/pages/RoomDetail.tsx
+++ b/src/pages/RoomDetail.tsx
@@ -104,8 +104,10 @@ const RoomDetail = () => {
             : syncedCurrentCycles
         }
         participants={getUserRankList(
-          syncedAllParticipants,
-          syncedAllLinkeduserIds
+          status === SOCKET_TIMER_STATUS.SET || !syncedAllParticipants 
+            ? userData.users
+            : syncedAllParticipants,
+          syncedAllLinkeduserIds  
         )}
         activeUsers={
           status === SOCKET_TIMER_STATUS.SET || !syncedAllParticipants

--- a/src/utils/getUserRankList.ts
+++ b/src/utils/getUserRankList.ts
@@ -1,9 +1,9 @@
 import { IParticipant } from "@/models/roomDetail.model";
 
 export const getUserRankList = (syncedAllParticipants: IParticipant[] | null, syncedAllLinkeduserIds: number[] | null): IParticipant[] | null => {
+    console.log(syncedAllLinkeduserIds, syncedAllParticipants)
     if (syncedAllParticipants === null || syncedAllLinkeduserIds === null) return null;
     return syncedAllParticipants
-        .sort((a, b) => b.pomodoroCount - a.pomodoroCount)
         .map((user) => ({
             ...user,
             isCurrentParticipant: syncedAllLinkeduserIds.includes(user.userId)


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 참여한 유저 정보의 코드 구조를 수정하였습니다.

### PR Point
- 기존 유저 정보 데이터는 초기값을 받아오고, 이후 소켓 통신 값이 있다면 대체하는 코드로 작성하였는데 소켓 연결과 동시에 유저 데이터를 받기에 소켓 값으로만 유저보드를 구성하도록 코드를 수정하였습니다.
- 방 정보에서 인원 표시 값 역시 실시간 변경 반영이 가능하도록 API값이 아닌 소켓값에서 추출하는 것으로 수정하였습니다.

closed #91 
