### PR TITLE
Fix: KaKao를 globalThis가 타입을 못찾는 오류를 해결

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -3,12 +3,3 @@ declare module "*.svg" {
   const content: any;
   export default content;
 }
-
-export {};
-
-declare global {
-  interface Window {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Kakao: any;
-  }
-}

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,8 @@
+export {};
+
+declare global {
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Kakao: any;
+  }
+}

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,8 +1,0 @@
-export {};
-
-declare global {
-  interface Window {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Kakao: any;
-  }
-}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-declare global {
+export declare global {
   interface Window {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Kakao: any;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -27,5 +27,5 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src", "global.d.ts"]
+  "include": ["src"]
 }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- KaKao를 globalThis가 타입을 못찾는 오류를 해결

### PR Point
- export declare global로 변경
- vite-env.d.ts 파일로 이동
